### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,10 @@ If you already have a Searchcraft index set up, you can jump straight to creatin
 - **Production Ready** → Better separation of concerns for production deployments
 - **Easier Debugging** → Test search functionality independently of the UI
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/searchcraft-inc-searchcraft-mcp-server).
+
 ## Getting Started
 
 ### Environment Variables


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/searchcraft-inc-searchcraft-mcp-server)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about hosted deployment availability with a link to access the hosted MCP server page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->